### PR TITLE
Fixed: TypeError: Can't convert 'bytes' object to str implicitly on p…

### DIFF
--- a/bitalino.py
+++ b/bitalino.py
@@ -445,7 +445,7 @@ class BITalino(object):
             dataAcquired = numpy.zeros((nSamples, 5 + nChannels))
             for sample in range(nSamples):
                 Data = self.receive(number_bytes)
-                decodedData = list(struct.unpack(number_bytes*"B ", Data))
+                decodedData = list(struct.unpack(number_bytes*"B ", bytes(Data,'latin1')))
                 crc = decodedData[-1] & 0x0F
                 decodedData[-1] = decodedData[-1] & 0xF0
                 x = 0
@@ -516,7 +516,7 @@ class BITalino(object):
                         finTime = time.time()
                         if (finTime - initTime) > self.timeout:
                             raise Exception(ExceptionCode.CONTACTING_DEVICE) 
-                data += self.socket.read(1)
+                data += self.socket.read(1).decode('latin1')
         else:
             while len(data) < nbytes:
                 if not self.blocking:
@@ -525,11 +525,12 @@ class BITalino(object):
                         pass
                     else:
                         raise Exception(ExceptionCode.CONTACTING_DEVICE)
-                data += self.socket.recv(1)      
+                data += self.socket.recv(1).decode('latin1')      
         return data
             
 if __name__ == '__main__':
     macAddress = "00:00:00:00:00:00"
+
     running_time = 5
     
     batteryThreshold = 30


### PR DESCRIPTION
Hi I am testing Bitalino with python3 on my RaspberryPi2 
and the code raised following error when receiving data from the device.
```
Traceback (most recent call last):
  File "bitalinoText.py", line 16, in <module>
    device = BITalino(macAddress)
  File "/usr/local/lib/python3.5/dist-packages/bitalino-1.0-py3.5.egg/bitalino.py", line 116, in __init__
    version = self.version()
  File "/usr/local/lib/python3.5/dist-packages/bitalino-1.0-py3.5.egg/bitalino.py", line 494, in version
    version_str += self.receive(1)
  File "/usr/local/lib/python3.5/dist-packages/bitalino-1.0-py3.5.egg/bitalino.py", line 528, in receive
    data += self.socket.recv(1)      
TypeError: Can't convert 'bytes' object to str implicitly
```
It seems it is due to the unicode string of Python3.
I am not sure decoding with "Latin1" is the correct way but it works on my environment.

Thank you.